### PR TITLE
Fix VR Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
 
                 camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 3, 100000 );
                 camera.position.z = 60;
+                window.addEventListener('vrdisplaypresentchange', () => {
+                    camera.position.z = 60;
+                });
 
                 controls = new THREE.OrbitControls( camera );
                 
@@ -290,10 +293,6 @@
 			function render() {
 				renderer.render( scene, camera );
 			}
-
-            window.addEventListener('vrdisplaypresentchange', () => {
-                camera.position.z = 60;
-            });
 		</script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -50,6 +50,11 @@
                 }, false);
 
                 renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
+
+                renderer.vr.enabled = true;
+                // HACK because vr does not play well with orbit controls
+                if (!renderer.vr._origGetCamera) renderer.vr._origGetCamera = renderer.vr.getCamera;
+
                 renderer.setPixelRatio( window.devicePixelRatio );
                 renderer.setSize( window.innerWidth, window.innerHeight );
                 container.appendChild( renderer.domElement );
@@ -270,8 +275,11 @@
                 requestAnimationFrame(animate);
                 resize();
                 // if vr is enabled three will handle the controls for us.
-                if (! renderer.vr.getDevice() || !renderer.vr.getDevice().isPresenting) {
+                if (renderer.vr.isPresenting()) {
+                    renderer.vr.getCamera = renderer.vr._origGetCamera;
+                } else {
                     controls.update();
+                    renderer.vr.getCamera = () => camera;
                 }
 
                 //raycastCheck();
@@ -282,6 +290,10 @@
 			function render() {
 				renderer.render( scene, camera );
 			}
+
+            window.addEventListener('vrdisplaypresentchange', () => {
+                camera.position.z = 60;
+            });
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
VR mode doesn't work unless you set `renderer.vr.enabled = true`. Unfortunately, this also breaks `OrbitControls` in non-VR mode, so I hacked in a fix for that as well.